### PR TITLE
Prevent error from being thrown

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -83,7 +83,9 @@ class FeedPlugin extends Plugin
         }
 
         // Overwrite regular content with feed config, so you can influence the collection processing with feed config
-        $page->header()->content = array_merge($page->header()->content, $this->feed_config);
+        if (property_exists($page->header(), 'content')) {
+            $page->header()->content = array_merge($page->header()->content, $this->feed_config);
+        }    
     }
 
     /**


### PR DESCRIPTION
This checks the header to see if the content property has been set before obtaining the property.